### PR TITLE
Allow profile path to be passed as an option in `build()`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ jspm_packages
 
 # Mac OS
 .DS_Store
+
+# Temporary files created by tests
+test/temp

--- a/lib/build.js
+++ b/lib/build.js
@@ -3,19 +3,47 @@
 /**
  * Module dependencies.
  */
+var path = require('path');
+var utilities = require('./utilities');
 var webdriver = require('selenium-webdriver');
 
 /**
  * Builds and launches a driver.
  *
- * @param  {String}    browserName - The browser name.
- * @return {WebDriver}
+ * @param  {String}    browserName      - The browser name.
+ * @param  {Object}    [browserOptions] - The build options.
+ * @return {WebDriver}                  - The driver instance.
  */
-module.exports = function build(browserName) {
-    if (typeof browserName !== 'string') {
-        throw new TypeError('First argument `browserName` is missing');
+module.exports = function build(browserName, browserOptions) {
+    if (typeof browserName === 'string') {
+        browserName = browserName.toLowerCase();
+    } else {
+        throw new TypeError('First argument `browserName` must be a string');
     }
+
     var builder = new webdriver.Builder();
     builder.forBrowser(browserName);
+
+    // browser options
+    if (typeof browserOptions === 'object') {
+        var client = require(path.join('selenium-webdriver', browserName));
+        var options = new client.Options();
+        var profile = browserOptions.profile;
+
+        // profile
+        if (profile && typeof profile === 'string') {
+            switch (browserName) {
+                case 'firefox':
+                    options.setProfile(profile);
+                    break;
+                case 'chrome':
+                    options.addArguments('user-data-dir=' + profile);
+                    break;
+            }
+        }
+
+        builder['set' + utilities.capitalize(browserName) + 'Options'](options);
+    }
+
     return builder.build();
 };

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -1,0 +1,21 @@
+'use strict';
+
+/**
+ * Capitalize string.
+ *
+ * @param  {String} string - The string.
+ * @return {String}
+ */
+function capitalize(string) {
+    if (typeof string !== 'string') {
+        throw new TypeError('First argument must be a string');
+    }
+    return string.charAt(0).toUpperCase() + string.slice(1);
+}
+
+/**
+ * Export utilities.
+ */
+module.exports = {
+    capitalize: capitalize
+};

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "scripts": {
     "test": "mocha",
-    "lint": "eslint .",
+    "lint": "eslint --ignore-path .gitignore .",
     "cover": "istanbul cover _mocha -- -R spec \"test/**/*\"",
     "coveralls": "cat coverage/lcov.info | coveralls"
   },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "test": "mocha",
     "lint": "eslint --ignore-path .gitignore .",
-    "cover": "istanbul cover _mocha -- -R spec \"test/**/*\"",
+    "cover": "istanbul cover _mocha -- \"test/*.js\"",
     "coveralls": "cat coverage/lcov.info | coveralls"
   },
   "repository": {

--- a/test/build.js
+++ b/test/build.js
@@ -28,15 +28,17 @@ test.describe('#build', function() {
         done();
     });
 
-    test.it('launches chrome with profile', function(done) {
-        var profilePath = 'test/temp/chrome-profile';
-        var driver = build('chrome', {
-            profile: profilePath
+    if (!process.env.TRAVIS) {
+        test.it('launches chrome with profile', function(done) {
+            var profilePath = 'test/temp/chrome-profile';
+            var driver = build('chrome', {
+                profile: profilePath
+            });
+            driver.getCapabilities().then(function(capabilities) {
+                assert.equal(capabilities.get('chrome').userDataDir, profilePath);
+            });
+            driver.quit();
+            done();
         });
-        driver.getCapabilities().then(function(capabilities) {
-            assert.equal(capabilities.get('chrome').userDataDir, profilePath);
-        });
-        driver.quit();
-        done();
-    });
+    }
 });

--- a/test/build.js
+++ b/test/build.js
@@ -4,8 +4,8 @@
  * Module dependencies.
  */
 var assert = require('assert');
-var test = require('selenium-webdriver/testing');
 var build = require('../lib/build');
+var test = require('selenium-webdriver/testing');
 
 /**
  * Build.
@@ -21,9 +21,22 @@ test.describe('#build', function() {
         }, Error);
     });
 
-    test.it('builds and launches a driver', function() {
+    test.it('launches a driver', function(done) {
         var driver = build('phantomjs');
         assert.equal(driver.constructor.name, 'thenableWebDriverProxy')
         driver.quit();
+        done();
+    });
+
+    test.it('launches chrome with profile', function(done) {
+        var profilePath = 'test/temp/chrome-profile';
+        var driver = build('chrome', {
+            profile: profilePath
+        });
+        driver.getCapabilities().then(function(capabilities) {
+            assert.equal(capabilities.get('chrome').userDataDir, profilePath);
+        });
+        driver.quit();
+        done();
     });
 });

--- a/test/saveScreenshot.js
+++ b/test/saveScreenshot.js
@@ -42,7 +42,7 @@ test.describe('#saveScreenshot', function() {
     });
 
     test.it('takes and writes the screenshot', function(done) {
-        var filename = 'test/temp.png';
+        var filename = 'test/temp/save-screenshot.png';
         saveScreenshot(driver, filename, function(error) {
             if (error) throw error;
 
@@ -51,7 +51,6 @@ test.describe('#saveScreenshot', function() {
                     fs.readFileSync(filename, 'base64'),
                     data.replace('data:image/png;base64')
                 );
-                fs.unlinkSync(filename);
                 done();
             });
         });

--- a/test/utilities.js
+++ b/test/utilities.js
@@ -1,0 +1,32 @@
+'use strict';
+
+/**
+ * Module dependencies.
+ */
+var assert = require('assert');
+var utilities = require('../lib/utilities');
+
+/**
+ * Utilities.
+ */
+describe('utilities', function() {
+
+    describe('#capitalize', function() {
+        var capitalize = utilities.capitalize;
+
+        it('throws an error if first argument is not a string', function() {
+            [undefined, null, 1, {}, [], Function].forEach(function(argument) {
+                assert.throws(function() {
+                    capitalize(argument);
+                }, TypeError);
+            });
+        });
+
+        it('capitalizes a string', function() {
+            assert.equal(capitalize(''), '');
+            assert.equal(capitalize('foo'), 'Foo');
+            assert.equal(capitalize('FOO'), 'FOO');
+        });
+    });
+
+});


### PR DESCRIPTION
References #2

#### Tasks:
- `build()`
  - A 2nd `browserOptions` parameter will allow the Firefox or Chrome profile path to be set
- `utilities`
  - `capitalize()`
    - Capitalizes a string (used in `build()`)
- Tests
  - Create `test/temp/` directory
  - The `saveScreenshot` test will use `test/temp/` directory and no longer unlink the png
  - Write test that checks setting a profile for Chrome works
    - Skip in Travis due to issues with setting up chromedriver
  - Write test for `utilities.capitalize()`
  - Update mocha to no longer recurse through directories (because of `test/temp/` directory)
- Update `.gitignore` and `eslint`

#### Todo:
- Update docs
- Allow `arguments` to be passed as well